### PR TITLE
Option to start Week period on Sunday and end on Saturday

### DIFF
--- a/src/CalendR/Calendar.php
+++ b/src/CalendR/Calendar.php
@@ -11,6 +11,7 @@
 
 namespace CalendR;
 
+use CalendR\Period\Day;
 use CalendR\Event\Manager;
 use CalendR\Period\PeriodInterface;
 
@@ -25,6 +26,39 @@ class Calendar
      * @var \CalendR\Event\Manager
      */
     private $eventManager;
+
+    static private $firstWeekday = Day::Monday;
+    
+    /**
+     * @param int $firstWeekday
+     *     First day of a week (Day::Sunday to Day::Saturday)
+     */
+    public function __construct($firstWeekday = Day::Monday)
+    {
+        $this->setFirstWeekday($firstWeekday);
+    }
+
+    /**
+     * @param int $firstWeekday
+     *     First day of a week (Day::Sunday to Day::Saturday)
+     */
+    static public function setFirstWeekday($firstWeekday)
+    {
+        if ($firstWeekday < Day::Sunday || $firstWeekday > Day::Saturday) {
+            throw new Exception('Invalid first weekday');
+        }
+                
+        self::$firstWeekday = $firstWeekday;
+    }
+
+    /**
+     * @return int
+     *     First day of a week (Day::Sunday to Day::Saturday)
+     */
+    static public function getFirstWeekday()
+    {
+        return self::$firstWeekday;
+    }
 
     /**
      * @param Manager $eventManager

--- a/src/CalendR/Period/Day.php
+++ b/src/CalendR/Period/Day.php
@@ -18,6 +18,14 @@ namespace CalendR\Period;
  */
 class Day extends PeriodAbstract
 {
+    const Sunday = 0;
+    const Monday = 1;
+    const Tuesday = 2;
+    const Wednesday = 3;
+    const Thursday = 4;
+    const Friday = 5;
+    const Saturday = 6;
+
     public function __construct(\DateTime $begin)
     {
         $this->begin = clone $begin;

--- a/src/CalendR/Period/Month.php
+++ b/src/CalendR/Period/Month.php
@@ -2,6 +2,8 @@
 
 namespace CalendR\Period;
 
+use CalendR\Calendar;
+
 /**
  * Represents a Month
  *
@@ -79,13 +81,15 @@ class Month extends PeriodAbstract implements \Iterator
      */
     public function getExtendedMonth()
     {
-        return new Range($this->getFirstMonday(), $this->getLastSunday());
+        return new Range($this->getFirstWeekday(), $this->getLastWeekday());
     }
 
     /**
      * Returns the monday of the first week of this month.
      *
      * @return \DateTime
+     * @deprecated
+     *      Use self::getFirstWeekday() instead.
      */
     public function getFirstMonday()
     {
@@ -102,6 +106,8 @@ class Month extends PeriodAbstract implements \Iterator
      * Returns the sunday of the last week of this month.
      *
      * @return \DateTime
+     * @deprecated
+     *      Use self::getLastWeekday() instead.
      */
     public function getLastSunday()
     {
@@ -112,6 +118,40 @@ class Month extends PeriodAbstract implements \Iterator
         $sunday->add(new \DateInterval(sprintf('P%sD', $delta)));
 
         return $sunday;
+    }    
+
+    /**
+     * Returns the first weekday of the first week of this month.
+     *
+     * @return \DateTime
+     */
+    public function getFirstWeekday()
+    {
+        $delta = $this->begin->format('w') ?: 7;
+        $delta -= Calendar::getFirstWeekday();
+
+        $first_weekday = clone $this->begin;
+        $first_weekday->sub(new \DateInterval(sprintf('P%sD', $delta)));
+
+        return $first_weekday;
+    }
+
+    /**
+     * Returns the last weekday of the last week of this month.
+     *
+     * @return \DateTime
+     */
+    public function getLastWeekday()
+    {
+        $last_weekday = clone $this->end;
+        $last_weekday->sub(new \DateInterval('P1D'));
+
+        $delta = 7 - ($this->firstWeekday->format('w') ?: 7);
+        $delta -= Calendar::getFirstWeekday();
+
+        $last_weekday->add(new \DateInterval(sprintf('P%sD', $delta)));
+
+        return $last_weekday;
     }
 
     /*
@@ -129,7 +169,7 @@ class Month extends PeriodAbstract implements \Iterator
     public function next()
     {
         if (!$this->valid()) {
-            $this->current = new Week($this->getFirstMonday());
+            $this->current = new Week($this->getFirstWeekday());
         } else {
             $this->current = $this->current->getNext();
 

--- a/src/CalendR/Period/Week.php
+++ b/src/CalendR/Period/Week.php
@@ -2,6 +2,8 @@
 
 namespace CalendR\Period;
 
+use CalendR\Calendar;
+
 /**
  * Represents a week
  *
@@ -62,7 +64,7 @@ class Week extends PeriodAbstract implements \Iterator
      */
     public static function isValid(\DateTime $start)
     {
-        if (1 != $start->format('w')) {
+        if (Calendar::getFirstWeekday() != $start->format('w')) {
             return false;
         }
 


### PR DESCRIPTION
I do have some code implementing feature request from issue #8, but I am not very happy about it. It adds a static variable $firstWeekday to the Calendar class that one can modify before making any other object or calling a method.

One should add some tests as this is a large change in calendar handling. Sorry about the code drop like this but it may be more useful than continue to keep it for myself.
