### PR TITLE
modification of provider to handle events without start or end

### DIFF
--- a/src/CalendR/Extension/GoogleCalendar/GoogleCalendarProvider.php
+++ b/src/CalendR/Extension/GoogleCalendar/GoogleCalendarProvider.php
@@ -103,7 +103,9 @@ class GoogleCalendarProvider implements ProviderInterface
         $events = array();
 
         foreach ($googleEvents['items'] as $item) {
+          if(isset($item['start']) && isset($item['end'])){
             $events[] = $this->createEvent($item, $calendarId);
+          }
         }
 
         return $events;


### PR DESCRIPTION
Cancelled events can produce errors since they do not have 'start' and 'end' attributes
