### PR TITLE
allow use of alternate Factory that implements FactoryInterface.

### DIFF
--- a/src/CalendR/Calendar.php
+++ b/src/CalendR/Calendar.php
@@ -13,6 +13,7 @@ namespace CalendR;
 
 use CalendR\Event\Manager;
 use CalendR\Period\Factory;
+use CalendR\Period\FactoryInterface;
 use CalendR\Period\PeriodInterface;
 
 /**
@@ -28,7 +29,7 @@ class Calendar
     private $eventManager;
 
     /**
-     * @var Factory
+     * @var FactoryInterface
      */
     protected $factory;
 
@@ -59,6 +60,10 @@ class Calendar
      */
     public function getYear($yearOrStart)
     {
+        if (!$yearOrStart instanceof \DateTime) {
+            $yearOrStart = new \DateTime(sprintf('%s-01-01', $yearOrStart));
+        }
+
         return $this->getFactory()->createYear($yearOrStart);
     }
 
@@ -70,7 +75,11 @@ class Calendar
      */
     public function getMonth($yearOrStart, $month = null)
     {
-        return $this->getFactory()->createMonth($yearOrStart, $month);
+        if (!$yearOrStart instanceof \DateTime) {
+            $yearOrStart = new \DateTime(sprintf('%s-%s-01', $yearOrStart, $month));
+        }
+
+        return $this->getFactory()->createMonth($yearOrStart);
     }
 
     /**
@@ -81,7 +90,11 @@ class Calendar
      */
     public function getWeek($yearOrStart, $week = null)
     {
-        return $this->getFactory()->createWeek($yearOrStart, $week);
+        if (!$yearOrStart instanceof \DateTime) {
+            $yearOrStart = new \DateTime(sprintf('%s-W%s', $yearOrStart, str_pad($week, 2, 0, STR_PAD_LEFT)));
+        }
+
+        return $this->getFactory()->createWeek($yearOrStart);
     }
 
     /**
@@ -93,7 +106,11 @@ class Calendar
      */
     public function getDay($yearOrStart, $month = null, $day = null)
     {
-        return $this->getFactory()->createDay($yearOrStart, $month, $day);
+        if (!$yearOrStart instanceof \DateTime) {
+            $yearOrStart = new \DateTime(sprintf('%s-%s-%s', $yearOrStart, $month, $day));
+        }
+
+        return $this->getFactory()->createDay($yearOrStart);
     }
 
     /**
@@ -108,15 +125,15 @@ class Calendar
     }
 
     /**
-     * @param Factory $factory
+     * @param FactoryInterface $factory
      */
-    public function setFactory(Factory $factory)
+    public function setFactory(FactoryInterface $factory)
     {
         $this->factory = $factory;
     }
 
     /**
-     * @return Factory
+     * @return FactoryInterface
      */
     public function getFactory()
     {
@@ -129,21 +146,17 @@ class Calendar
 
     /**
      * @param int $firstWeekday
-     *
-     * @deprecated Deprecated since version 1.1, to be removed in 2.0. Use {@link setOption('first_weekday')} instead.
      */
     public function setFirstWeekday($firstWeekday)
     {
-        $this->getFactory()->setOption('first_weekday', $firstWeekday);
+        $this->getFactory()->setFirstWeekday($firstWeekday);
     }
 
     /**
      * @return int
-     *
-     * @deprecated Deprecated since version 1.1, to be removed in 2.0. Use {@link getOption('first_weekday')} instead.
      */
     public function getFirstWeekday()
     {
-        return $this->factory->getOption('first_weekday');
+        return $this->factory->getFirstWeekday();
     }
 }

--- a/src/CalendR/Period/Day.php
+++ b/src/CalendR/Period/Day.php
@@ -27,8 +27,8 @@ class Day extends PeriodAbstract
     const SUNDAY    = 0;
 
     /**
-     * @param \DateTime $begin
-     * @param Factory   $factory
+     * @param \DateTime        $begin
+     * @param FactoryInterface $factory
      */
     public function __construct(\DateTime $begin, $factory = null)
     {

--- a/src/CalendR/Period/Factory.php
+++ b/src/CalendR/Period/Factory.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  *
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class Factory
+class Factory implements FactoryInterface
 {
     /**
      * @var array
@@ -42,83 +42,41 @@ class Factory
     }
 
     /**
-     * Creates and returns a new Day instance
-     *
-     * @param int|\DateTime $yearOrStart
-     * @param int|array     $month
-     * @param int           $day
-     *
-     * @return \CalendR\Period\Day
+     * {@inheritDoc}
      */
-    public function createDay($yearOrStart, $month = null, $day = null)
+    public function createDay(\DateTime $begin)
     {
-        if (!$yearOrStart instanceof \DateTime) {
-            $yearOrStart = new \DateTime(sprintf('%s-%s-%s', $yearOrStart, $month, $day));
-        }
-
-        return new $this->options['day_class']($yearOrStart, $this);
+        return new $this->options['day_class']($begin, $this);
     }
 
     /**
-     * Creates and returns a new week instance
-     *
-     * @param int|\DateTime $yearOrStart
-     * @param int|array     $week
-     *
-     * @return \CalendR\Period\Week
+     * {@inheritDoc}
      */
-    public function createWeek($yearOrStart, $week = null)
+    public function createWeek(\DateTime $begin)
     {
-        if (!$yearOrStart instanceof \DateTime) {
-            $yearOrStart = new \DateTime(sprintf('%s-W%s', $yearOrStart, str_pad($week, 2, 0, STR_PAD_LEFT)));
-        }
-
-        return new $this->options['week_class']($yearOrStart, $this);
+        return new $this->options['week_class']($begin, $this);
     }
 
     /**
-     * Creates and returns a new month
-     *
-     * @param int|\DateTime $yearOrStart
-     * @param int|array     $month
-     *
-     * @return \CalendR\Period\Month
+     * {@inheritDoc}
      */
-    public function createMonth($yearOrStart, $month = null)
+    public function createMonth(\DateTime $begin)
     {
-        if (!$yearOrStart instanceof \DateTime) {
-            $yearOrStart = new \DateTime(sprintf('%s-%s-01', $yearOrStart, $month));
-        }
-
-        return new $this->options['month_class']($yearOrStart, $this);
+        return new $this->options['month_class']($begin, $this);
     }
 
     /**
-     * Creates and returns a new year
-     *
-     * @param int|\DateTime $yearOrStart
-     * @param array         $options
-     *
-     * @return \CalendR\Period\Year
+     * {@inheritDoc}
      */
-    public function createYear($yearOrStart, array $options = array())
+    public function createYear(\DateTime $begin)
     {
-        if (!$yearOrStart instanceof \DateTime) {
-            $yearOrStart = new \DateTime(sprintf('%s-01-01', $yearOrStart));
-        }
-
-        return new $this->options['year_class']($yearOrStart, $this);
+        return new $this->options['year_class']($begin, $this);
     }
 
     /**
-     * Creates and returns a new range
-     *
-     * @param int|\DateTime $begin
-     * @param int|\DateTime $end
-     *
-     * @return \CalendR\Period\Range
+     * {@inheritDoc}
      */
-    public function createRange($begin, $end)
+    public function createRange(\DateTime $begin, \DateTime $end)
     {
         return new $this->options['range_class']($begin, $end, $this);
     }
@@ -175,5 +133,21 @@ class Factory
      */
     protected function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setFirstWeekday($firstWeekday)
+    {
+        $this->setOption('first_weekday', $firstWeekday);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFirstWeekday()
+    {
+        return $this->getOption('first_weekday');
     }
 }

--- a/src/CalendR/Period/FactoryInterface.php
+++ b/src/CalendR/Period/FactoryInterface.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * This file is part of CalendR, a Fréquence web project.
+ *
+ * (c) 2012 Fréquence web
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CalendR\Period;
+
+/**
+ * Class FactoryInterface
+ *
+ * @package CalendR\Period
+ */
+interface FactoryInterface
+{
+    /**
+     * Create and return a Day
+     *
+     * @param \DateTime $begin
+     * @return \CalendR\Period\PeriodInterface
+     */
+    public function createDay(\DateTime $begin);
+
+    /**
+     * Create and return a Week
+     *
+     * @param \DateTime $begin
+     * @return \CalendR\Period\PeriodInterface
+     */
+    public function createWeek(\DateTime $begin);
+
+    /**
+     * Create and return a Month
+     *
+     * @param \DateTime $begin
+     * @return \CalendR\Period\PeriodInterface
+     */
+    public function createMonth(\DateTime $begin);
+
+    /**
+     * Create and return a Year
+     *
+     * @param \DateTime $begin
+     * @return \CalendR\Period\PeriodInterface
+     */
+    public function createYear(\DateTime $begin);
+
+    /**
+     * Create and return a Range
+     *
+     * @param \DateTime $begin
+     * @param \DateTime $end
+     * @return \CalendR\Period\PeriodInterface
+     */
+    public function createRange(\DateTime $begin, \DateTime $end);
+
+    /**
+     * @param integer $firstWeekday
+     * @return null
+     */
+    public function setFirstWeekday($firstWeekday);
+
+    /**
+     * @return integer
+     */
+    public function getFirstWeekday();
+}

--- a/src/CalendR/Period/Month.php
+++ b/src/CalendR/Period/Month.php
@@ -15,8 +15,8 @@ class Month extends PeriodAbstract implements \Iterator
     private $current;
 
     /**
-     * @param  \DateTime $start
-     * @param  Factory   $factory
+     * @param \DateTime        $start
+     * @param FactoryInterface $factory
      *
      * @throws Exception\NotAMonth
      */
@@ -67,7 +67,7 @@ class Month extends PeriodAbstract implements \Iterator
     public function getFirstDayOfFirstWeek()
     {
         $delta  = $this->begin->format('w') ?: 7;
-        $delta -= $this->getFactory()->getOption('first_weekday');
+        $delta -= $this->getFactory()->getFirstWeekday();
         $delta  = $delta < 0 ? 7 - abs($delta) : $delta;
         $delta  = $delta == 7 ? 0 : $delta;
 
@@ -78,7 +78,7 @@ class Month extends PeriodAbstract implements \Iterator
     }
 
     /**
-     * Returns a Range period begining at the first day of first week of this month,
+     * Returns a Range period beginning at the first day of first week of this month,
      * and ending at the last day of the last week of this month.
      *
      * @return Range
@@ -98,9 +98,9 @@ class Month extends PeriodAbstract implements \Iterator
     {
         $lastDay = clone $this->end;
         $lastDay->sub(new \DateInterval('P1D'));
-        $lastWeekday = $this->getFactory()->getOption('first_weekday') === Day::SUNDAY ?
+        $lastWeekday = $this->getFactory()->getFirstWeekday() === Day::SUNDAY ?
             Day::SATURDAY :
-            $this->getFactory()->getOption('first_weekday') - 1;
+            $this->getFactory()->getFirstWeekday() - 1;
 
         $delta = intval($lastDay->format('w')) - $lastWeekday;
         $delta = 7 - ($delta < 0 ? $delta + 7 : $delta);

--- a/src/CalendR/Period/PeriodAbstract.php
+++ b/src/CalendR/Period/PeriodAbstract.php
@@ -32,12 +32,12 @@ abstract class PeriodAbstract implements PeriodInterface
     protected $end;
 
     /**
-     * @var Factory
+     * @var FactoryInterface
      */
     protected $factory;
 
     /**
-     * @param  Factory|int $factory
+     * @param FactoryInterface|int $factory
      *
      * @throws Exception\NotAWeekday
      * @throws Exception\InvalidArgument
@@ -47,8 +47,8 @@ abstract class PeriodAbstract implements PeriodInterface
         if (is_numeric($factory)) { // for backwards compatibility
             $factory = new Factory(array('first_weekday' => $factory));
         }
-        if (!(null === $factory || $factory instanceof Factory)) {
-            throw new Exception\InvalidArgument('Factory parameter must be an instance of CalendR\Period\Factory');
+        if (!(null === $factory || $factory instanceof FactoryInterface)) {
+            throw new Exception\InvalidArgument('Factory parameter must implement CalendR\Period\FactoryInterface');
         }
 
         $this->factory = $factory;
@@ -188,7 +188,7 @@ abstract class PeriodAbstract implements PeriodInterface
     }
 
     /**
-     * @return Factory
+     * @return FactoryInterface
      */
     public function getFactory()
     {
@@ -202,19 +202,17 @@ abstract class PeriodAbstract implements PeriodInterface
     /**
      * @param  int  $firstWeekday
      * @return void
-     * @deprecated Deprecated since version 1.1, to be removed in 2.0. Use {@link Factory::setOption('first_weekday')} instead.
      */
     public function setFirstWeekday($firstWeekday)
     {
-        $this->getFactory()->setOption('first_weekday', $firstWeekday);
+        $this->getFactory()->setFirstWeekday($firstWeekday);
     }
 
     /**
      * @return int
-     * @deprecated Deprecated since version 1.1, to be removed in 2.0. Use {@link Factory::getOption('first_weekday')} instead.
      */
     public function getFirstWeekday()
     {
-        return $this->getFactory()->getOption('first_weekday');
+        return $this->getFactory()->getFirstWeekday();
     }
 }

--- a/src/CalendR/Period/Range.php
+++ b/src/CalendR/Period/Range.php
@@ -19,9 +19,9 @@ namespace CalendR\Period;
 class Range extends PeriodAbstract
 {
     /**
-     * @param \DateTime $begin
-     * @param \DateTime $end
-     * @param Factory   $factory
+     * @param \DateTime        $begin
+     * @param \DateTime        $end
+     * @param FactoryInterface $factory
      */
     public function __construct(\DateTime $begin, \DateTime $end, $factory = null)
     {

--- a/src/CalendR/Period/Week.php
+++ b/src/CalendR/Period/Week.php
@@ -15,8 +15,8 @@ class Week extends PeriodAbstract implements \Iterator
     private $current = null;
 
     /**
-     * @param  \DateTime $start
-     * @param  Factory   $factory
+     * @param \DateTime        $start
+     * @param FactoryInterface $factory
      *
      * @throws Exception\NotAWeek
      */

--- a/src/CalendR/Period/Year.php
+++ b/src/CalendR/Period/Year.php
@@ -15,8 +15,8 @@ class Year extends PeriodAbstract implements \Iterator
     private $current;
 
     /**
-     * @param  \DateTime $begin
-     * @param  Factory   $factory
+     * @param \DateTime        $begin
+     * @param FactoryInterface $factory
      *
      * @throws Exception\NotAYear
      */

--- a/tests/CalendR/Test/Period/AlternatePeriodsTest.php
+++ b/tests/CalendR/Test/Period/AlternatePeriodsTest.php
@@ -55,9 +55,9 @@ class AlternatePeriodsTest extends \PHPUnit_Framework_TestCase
     public function testCalendarGetOption()
     {
         $calendar = new Calendar();
-        $this->assertEquals(1, $calendar->getFactory()->getOption('first_weekday'));
+        $this->assertEquals(1, $calendar->getFactory()->getFirstWeekday());
         $calendar->setFactory(new Factory(array('first_weekday' => 0)));
-        $this->assertEquals(0, $calendar->getFactory()->getOption('first_weekday'));
+        $this->assertEquals(0, $calendar->getFactory()->getFirstWeekday());
     }
 
     public function testYear()

--- a/tests/CalendR/Test/Period/FactoryTest.php
+++ b/tests/CalendR/Test/Period/FactoryTest.php
@@ -3,6 +3,7 @@
 namespace CalendR\Test\Period;
 
 use CalendR\Period\Factory;
+use CalendR\Period\FactoryInterface;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
@@ -11,14 +12,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreateDay()
     {
-        $this->assertInstanceOf('CalendR\Period\Day', $this->getDefaultOptionsFactory()->createDay(2012, 1, 1));
         $this->assertInstanceOf(
             'CalendR\Period\Day',
             $this->getDefaultOptionsFactory()->createDay(new \DateTime('2012-01-01'))
-        );
-        $this->assertInstanceOf(
-            'CalendR\Test\Fixtures\Period\Day',
-            $this->getAlternateOptionsFactory()->createDay(2012, 1, 1)
         );
         $this->assertInstanceOf(
             'CalendR\Test\Fixtures\Period\Day',
@@ -29,11 +25,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateWeek()
     {
         $this->assertInstanceOf('CalendR\Period\Week', $this->getDefaultOptionsFactory()->createWeek(new \DateTime('2012-W01')));
-        $this->assertInstanceOf('CalendR\Period\Week', $this->getDefaultOptionsFactory()->createWeek(2012, 1));
-        $this->assertInstanceOf(
-            'CalendR\Test\Fixtures\Period\Week',
-            $this->getAlternateOptionsFactory()->createWeek(2012, 1)
-        );
         $this->assertInstanceOf(
             'CalendR\Test\Fixtures\Period\Week',
             $this->getAlternateOptionsFactory()->createWeek(new \DateTime('2012-W01'))
@@ -43,11 +34,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateMonth()
     {
         $this->assertInstanceOf('CalendR\Period\Month', $this->getDefaultOptionsFactory()->createMonth(new \DateTime('2012-01-01')));
-        $this->assertInstanceOf('CalendR\Period\Month', $this->getDefaultOptionsFactory()->createMonth(2012, 1));
-        $this->assertInstanceOf(
-            'CalendR\Test\Fixtures\Period\Month',
-            $this->getAlternateOptionsFactory()->createMonth(2012, 1)
-        );
         $this->assertInstanceOf(
             'CalendR\Test\Fixtures\Period\Month',
             $this->getAlternateOptionsFactory()->createMonth(new \DateTime('2012-01-01'))
@@ -57,11 +43,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateYear()
     {
         $this->assertInstanceOf('CalendR\Period\Year', $this->getDefaultOptionsFactory()->createYear(new \DateTime('2012-01-01')));
-        $this->assertInstanceOf('CalendR\Period\Year', $this->getDefaultOptionsFactory()->createYear(2012));
-        $this->assertInstanceOf(
-            'CalendR\Test\Fixtures\Period\Year',
-            $this->getAlternateOptionsFactory()->createYear(2012)
-        );
         $this->assertInstanceOf(
             'CalendR\Test\Fixtures\Period\Year',
             $this->getAlternateOptionsFactory()->createYear(new \DateTime('2012-01-01'))
@@ -81,7 +62,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return Factory
+     * @return FactoryInterface
      */
     protected function getDefaultOptionsFactory()
     {
@@ -89,7 +70,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return Factory
+     * @return FactoryInterface
      */
     protected function getAlternateOptionsFactory()
     {


### PR DESCRIPTION
This PR modifies the present alternate-periods branch to allow use of alternate Factory that implements a new FactoryInterface, rather than having to extend CalendR\Period\Factory as it would with the current. It also moves the alternate period creation logic used by Calendar.php back to Calendar.php from Period/Factory.php, to simplify the Factory Interface. FactoryTest is modified to reflect these changes.

I have not changed the phpdoc "@return" statements in Factory and elsewhere that assume that FactoryInterface methods return objects that extend CalendR\Period\ objects. I note that the AlternatePeriodsTest only verifies that the code will handle alternate period objects that extend those objects.

 It might be useful to permit alternate period objects that implement PeriodInterface (or, better, an Interface specific to Year, Month, Week, Day and Range objects) without having to extend the existing objects.  

If AlternatePeriodsTest reflects what you consider to be the required behavior of any Year, Month, Week, Day or Range object, then I could work out the interfaces from that.
