### PR TITLE
make Week iterator external (WeekIterator)

### DIFF
--- a/src/CalendR/Period/Factory.php
+++ b/src/CalendR/Period/Factory.php
@@ -141,10 +141,13 @@ class Factory implements FactoryInterface
                     'hour_class'    => 'CalendR\Period\Hour',
                     'day_class'     => 'CalendR\Period\Day',
                     'week_class'    => 'CalendR\Period\Week',
+                    'week_iterator_class' => 'CalendR\Period\WeekIterator',
+                    'weekdays_iterator_class' => 'CalendR\Period\WeekdaysIterator',
                     'month_class'   => 'CalendR\Period\Month',
                     'year_class'    => 'CalendR\Period\Year',
                     'range_class'   => 'CalendR\Period\Range',
                     'first_weekday' => Day::MONDAY,
+                    'weekdays_only' => false,
                     'strict_dates'  => false,
                 )
             );

--- a/src/CalendR/Period/FactoryInterface.php
+++ b/src/CalendR/Period/FactoryInterface.php
@@ -101,4 +101,11 @@ interface FactoryInterface
      * @return \DateTime
      */
     public function findFirstDayOfWeek($dateTime);
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getOption($name);
 }

--- a/src/CalendR/Period/PeriodInterface.php
+++ b/src/CalendR/Period/PeriodInterface.php
@@ -125,4 +125,9 @@ interface PeriodInterface
      * @return \DateInterval
      */
     public static function getDateInterval();
+
+    /**
+     * @return FactoryInterface
+     */
+    public function getFactory();
 }

--- a/src/CalendR/Period/Week.php
+++ b/src/CalendR/Period/Week.php
@@ -7,12 +7,9 @@ namespace CalendR\Period;
  *
  * @author Yohan Giarelli <yohan@giarel.li>
  */
-class Week extends PeriodAbstract implements \Iterator
+class Week extends PeriodAbstract implements \IteratorAggregate
 {
-    /**
-     * @var null|PeriodInterface
-     */
-    private $current = null;
+    private $iterator;
 
     /**
      * @param \DateTime        $start
@@ -61,52 +58,24 @@ class Week extends PeriodAbstract implements \Iterator
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function current()
+    public function getIterator()
     {
-        return $this->current;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function next()
-    {
-        if (!$this->valid()) {
-            $this->current = $this->getFactory()->createDay($this->begin);
-        } else {
-            $this->current = $this->current->getNext();
-            if (!$this->contains($this->current->getBegin())) {
-                $this->current = null;
-            }
+        if (null == $this->iterator) {
+            $factory = $this->getFactory();
+            $option = ($factory->getOption('weekdays_only')) ? 'weekdays_iterator_class' : 'week_iterator_class';
+            $class = $factory->getOption($option);
+            $this->iterator = new $class($this);
         }
+
+        return $this->iterator;
     }
 
     /**
-     * {@inheritDoc}
+     * @param \Iterator $iterator
      */
-    public function key()
+    public function setIterator($iterator)
     {
-        return $this->current->getBegin()->format('d-m-Y');
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function valid()
-    {
-        return null !== $this->current;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function rewind()
-    {
-        $this->current = null;
-        $this->next();
+        $this->iterator = $iterator;
     }
 
     /**

--- a/src/CalendR/Period/WeekIterator.php
+++ b/src/CalendR/Period/WeekIterator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CalendR\Period;
+
+class WeekIterator implements \Iterator
+{
+    /**
+     * @var null|\DateTime
+     */
+    protected $current = null;
+
+    protected $week;
+
+    public function __construct(PeriodInterface $week)
+    {
+        $this->week = $week;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function current()
+    {
+        return $this->week->getFactory()->createDay($this->current);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function next()
+    {
+        $dayInterval = new \DateInterval('P1D');
+        if (!$this->valid()) {
+            $this->current = clone $this->week->getBegin();
+        } else {
+            $this->current->add(new \DateInterval('P1D'));
+            if (!$this->week->contains($this->current)) {
+                $this->current = null;
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function key()
+    {
+        return $this->current->format('d-m-Y');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function valid()
+    {
+        return null !== $this->current;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rewind()
+    {
+        $this->current = null;
+        $this->next();
+    }
+}

--- a/src/CalendR/Period/WeekdaysIterator.php
+++ b/src/CalendR/Period/WeekdaysIterator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CalendR\Period;
+
+class WeekdaysIterator extends WeekIterator
+{
+    public function next()
+    {
+        $dayInterval = new \DateInterval('P1D');
+        if (!$this->valid()) {
+            $this->current = clone $this->week->getBegin();
+        } else {
+            $this->current->add($dayInterval);
+        }
+        while (5 < $this->current->format('N')) { // skip SATURDAY and SUNDAY
+            $this->current->add($dayInterval);
+        }
+        if (!$this->week->contains($this->current)) {
+            $this->current = null;
+        }
+    }
+}

--- a/tests/CalendR/Test/CalendarTest.php
+++ b/tests/CalendR/Test/CalendarTest.php
@@ -145,7 +145,7 @@ class CalendarTest extends \PHPUnit_Framework_TestCase
             array(2013, 8, Day::SUNDAY, '2013-02-17'),
         );
     }
-    
+
     public function testStrictDates()
     {
         // When we start, the option "strict_dates" should be set to false.

--- a/tests/CalendR/Test/Period/DayTest.php
+++ b/tests/CalendR/Test/Period/DayTest.php
@@ -3,7 +3,6 @@
 namespace CalendR\Test\Period;
 
 use CalendR\Period\Day;
-use CalendR\Period\Month;
 use CalendR\Period\PeriodInterface;
 use CalendR\Period\Year;
 
@@ -119,7 +118,7 @@ class DayTest extends \PHPUnit_Framework_TestCase
     public function testToString()
     {
         $day = new Day(new \DateTime(date('Y-m-d')));
-        $this->assertSame($day->getBegin()->format('l'), (string)$day);
+        $this->assertSame($day->getBegin()->format('l'), (string) $day);
     }
 
     public function testIsValid()

--- a/tests/CalendR/Test/Period/WeekIteratorsTest.php
+++ b/tests/CalendR/Test/Period/WeekIteratorsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace CalendR\Test\Period;
+
+use CalendR\Calendar;
+use CalendR\Period\Factory;
+use CalendR\Period\Month;
+use CalendR\Period\Week;
+use CalendR\Period\Year;
+
+class WeekIteratorsTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var $calendar Calendar */
+    protected $calendar;
+
+    protected function setUp()
+    {
+        $this->calendar = new Calendar();
+    }
+
+    public static function providerIteratorOptions()
+    {
+        return array(
+            array(array(), 'CalendR\Period\WeekIterator'),
+            array(array('weekdays_only'=> true), 'CalendR\Period\WeekDaysIterator'),
+        );
+    }
+
+    /**
+     * @dataProvider providerIteratorOptions
+     */
+    public function testWeekDaysOnlyOption($options, $iteratorClass)
+    {
+        $calendar = new Calendar;
+        $calendar->setFactory(new Factory($options));
+        /* @var $week Week */
+        $week = $calendar->getWeek(new \DateTime('2012W01'));
+        $this->assertInstanceOf($iteratorClass, $week->getIterator());
+    }
+
+    /**
+     * @dataProvider providerIteratorOptions
+     */
+    public function testYear($options, $iteratorClass)
+    {
+        $year = new Year(new \DateTime('2013-01-01'), new Factory($options));
+        foreach ($year as $month) {
+            $this->assertInstanceOf('CalendR\Period\Month', $month);
+            /* @var $week Week */
+            foreach ($month as $week) {
+                $this->assertInstanceOf('CalendR\Period\Week', $week);
+                $this->assertInstanceOf($iteratorClass, $week->getIterator());
+            }
+        }
+    }
+
+    /**
+     * @dataProvider providerIteratorOptions
+     */
+    public function testMonth($options, $iteratorClass)
+    {
+        $month = new Month(new \DateTime('2013-01-01'), new Factory($options));
+        /* @var $week Week */
+        foreach ($month as $week) {
+            $this->assertInstanceOf('CalendR\Period\Week', $week);
+            $this->assertInstanceOf($iteratorClass, $week->getIterator());
+        }
+    }
+
+    /**
+     * @dataProvider providerIteratorOptions
+     */
+    public function testWeek($options, $iteratorClass)
+    {
+        $week = new Week(new \DateTime('2013W01'), new Factory($options));
+        foreach ($week as $day) {
+            $this->assertInstanceOf('CalendR\Period\Day', $day);
+            $this->assertInstanceOf($iteratorClass, $week->getIterator());
+        }
+    }
+}

--- a/tests/CalendR/Test/Stubs/EventRepository.php
+++ b/tests/CalendR/Test/Stubs/EventRepository.php
@@ -9,5 +9,4 @@ class EventRepository extends EntityRepository
 {
     use EventRepositoryTrait;
 
-
 }


### PR DESCRIPTION
add alternate WeekdaysIterator
add week_iterator_class, weekdays_iterator_class and weekdays_only options to factory
add getOption() to FactoryInterface
add getFactory to PeriodInterface
add WeekIteratorsTest
cs fix (affects DayTest, Stubs/EventRepository and CalendarTest)

This backwards compatible PR allows a configuration in which iteration of Week objects returns just the Day objects that correspond to weekdays -- by setting the 'weekdays_only' factory option to true.  
