### PR TITLE
Clone Period Dates

### DIFF
--- a/src/CalendR/Period/PeriodAbstract.php
+++ b/src/CalendR/Period/PeriodAbstract.php
@@ -176,7 +176,7 @@ abstract class PeriodAbstract implements PeriodInterface
      */
     public function getBegin()
     {
-        return $this->begin;
+        return clone $this->begin;
     }
 
     /**
@@ -184,7 +184,7 @@ abstract class PeriodAbstract implements PeriodInterface
      */
     public function getEnd()
     {
-        return $this->end;
+        return clone $this->end;
     }
 
     /**


### PR DESCRIPTION
For a time period, the `getBegin()` and `getEnd()` methods should return cloned versions of the periods begin and end times, not the date objects themselves.

At present, changing an object returned from either one of these objects changes the time period itself which should be done manually via other methods, or creating a new period via the Factory.