### PR TITLE
OptionsResolverInterface is depricated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": ">=5.3.0",
-        "symfony/options-resolver": ">=2.1,<3.0"
+        "symfony/options-resolver": ">=2.1,<2.6"
     },
 
     "require-dev": {


### PR DESCRIPTION
In Symfony > 2.5 the Symfony\Component\OptionsResolver got deprecated. Obviously this issue has to be addressed somehow, but in the meantime this is a quick fix to avoid problems while updating dependencies