### PR TITLE
Adds support for Symfony 4 and Twig 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 sudo: false
 php:
-    - 5.5
     - 5.6
-    - 7
+    - 7.0
+    - 7.1
     - hhvm
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         "homepage": "http://yohan.giarel.li"
     }],
     "require": {
-        "php": "^5.5|^7.0",
-        "symfony/options-resolver": "^2.7|^3.0"
+        "php": "^5.6|^7.0",
+        "symfony/options-resolver": "^2.7|^3.0|^4.0"
     },
 
     "require-dev": {
         "doctrine/cache":               "^1.5",
         "doctrine/common":              "^2.5",
         "doctrine/orm":                 "^2.5",
-        "phpunit/phpunit":              "^4.0",
+        "phpunit/phpunit":              "^5.7",
         "silex/silex":                  "^1.3",
-        "twig/twig":                    "^1.23"
+        "twig/twig":                    "^1.23|^2.0"
     },
 
     "autoload": {

--- a/src/CalendR/Period/Second.php
+++ b/src/CalendR/Period/Second.php
@@ -26,7 +26,9 @@ class Second extends PeriodAbstract
      */
     public static function isValid(\DateTime $start)
     {
-        return $start->format('u') === '000000';
+        // keeping microsecond check for backwards compatability with PHP < 7.1
+        // otherwise, any DateTime is valid, even with microseconds
+        return PHP_VERSION_ID < 70100 ? $start->format('u') === '000000' : true;
     }
 
     /**

--- a/tests/CalendR/Test/BaseDoctrine2TestCase.php
+++ b/tests/CalendR/Test/BaseDoctrine2TestCase.php
@@ -88,7 +88,7 @@ class BaseDoctrine2TestCase extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $config = $this->getMock($configurationClass, $mockMethods);
+        $config = $this->createMock($configurationClass, $mockMethods);
 
         $config
             ->expects($this->once())

--- a/tests/CalendR/Test/CalendarTest.php
+++ b/tests/CalendR/Test/CalendarTest.php
@@ -86,9 +86,9 @@ class CalendarTest extends \PHPUnit_Framework_TestCase
 
     public function testGetEvents()
     {
-        $em       = $this->getMock('CalendR\Event\Manager');
-        $period   = $this->getMock('CalendR\Period\PeriodInterface');
-        $events   = array($this->getMock('CalendR\Event\EventInterface'));
+        $em       = $this->createMock('CalendR\Event\Manager');
+        $period   = $this->createMock('CalendR\Period\PeriodInterface');
+        $events   = array($this->createMock('CalendR\Event\EventInterface'));
         $calendar = new Calendar;
         $calendar->setEventManager($em);
         $em->expects($this->once())->method('find')->with($period, array())->will($this->returnValue($events));
@@ -99,7 +99,7 @@ class CalendarTest extends \PHPUnit_Framework_TestCase
     public function testGetFirstWeekday()
     {
         $calendar = new Calendar;
-        $factory  = $this->getMock('CalendR\Period\FactoryInterface');
+        $factory  = $this->createMock('CalendR\Period\FactoryInterface');
         $calendar->setFactory($factory);
         $factory->expects($this->once())->method('getFirstWeekday')->will($this->returnValue(Day::SUNDAY));
 

--- a/tests/CalendR/Test/Event/Provider/AggregateTest.php
+++ b/tests/CalendR/Test/Event/Provider/AggregateTest.php
@@ -27,8 +27,8 @@ class AggregateTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->provider1 = $this->getMock('CalendR\Event\Provider\ProviderInterface');
-        $this->provider2 = $this->getMock('CalendR\Event\Provider\ProviderInterface');
+        $this->provider1 = $this->createMock('CalendR\Event\Provider\ProviderInterface');
+        $this->provider2 = $this->createMock('CalendR\Event\Provider\ProviderInterface');
         $this->object    = new Aggregate(array($this->provider1));
     }
 
@@ -47,8 +47,8 @@ class AggregateTest extends \PHPUnit_Framework_TestCase
     {
         $begin  = new \DateTime;
         $end    = new \DateTime;
-        $event1 = $this->getMock('CalendR\Event\EventInterface');
-        $event2 = $this->getMock('CalendR\Event\EventInterface');
+        $event1 = $this->createMock('CalendR\Event\EventInterface');
+        $event2 = $this->createMock('CalendR\Event\EventInterface');
 
         $this->provider1->expects($this->once())->method('getEvents')->with($begin, $end)->will($this->returnValue(array($event1)));
         $this->provider2->expects($this->once())->method('getEvents')->with($begin, $end)->will($this->returnValue(array($event2)));

--- a/tests/CalendR/Test/Event/Provider/CacheTest.php
+++ b/tests/CalendR/Test/Event/Provider/CacheTest.php
@@ -29,8 +29,8 @@ class CacheTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->cache    = $this->getMock('Doctrine\Common\Cache\Cache');
-        $this->provider = $this->getMock('CalendR\Event\Provider\ProviderInterface');
+        $this->cache    = $this->createMock('Doctrine\Common\Cache\Cache');
+        $this->provider = $this->createMock('CalendR\Event\Provider\ProviderInterface');
         $this->object = new Cache($this->cache, $this->provider, 3600);
     }
 

--- a/tests/CalendR/Test/Extension/Doctrine2/EventRepositoryTest.php
+++ b/tests/CalendR/Test/Extension/Doctrine2/EventRepositoryTest.php
@@ -33,7 +33,7 @@ class EventRepositoryTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('You need PHP5.4 to use and test traits.');
         }
 
-        $this->em            = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $this->em            = $this->createMock('Doctrine\ORM\EntityManagerInterface');
         $this->classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')
             ->disableOriginalConstructor()
             ->getMock();
@@ -64,7 +64,7 @@ class EventRepositoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetEvents($begin, $end, array $providedEvents)
     {
-        $expr  = $this->getMock('Doctrine\ORM\Query\Expr');
+        $expr  = $this->createMock('Doctrine\ORM\Query\Expr');
         $query = $this->getMockBuilder('Doctrine\ORM\AbstractQuery')
             ->disableOriginalConstructor()
             ->setMethods(array('_doExecute', 'getSQL', 'execute', 'getResult'))

--- a/tests/CalendR/Test/Extension/Silex/CalendRServiceProviderTest.php
+++ b/tests/CalendR/Test/Extension/Silex/CalendRServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace CalendR\Test\Extension\Silex;
 
 use CalendR\Extension\Silex\Provider\CalendRServiceProvider;
+use CalendR\Extension\Twig\CalendRExtension;
 use CalendR\Event\Provider;
 use Silex\Application;
 use Silex\Provider\TwigServiceProvider;
@@ -54,6 +55,6 @@ class CalendRServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->app->register($this->provider);
         $this->app->register(new TwigServiceProvider());
         $this->app->boot();
-        $this->assertInstanceOf('CalendR\\Extension\\Twig\\CalendRExtension', $this->app['twig']->getExtension('calendr'));
+        $this->assertInstanceOf(CalendRExtension::class, $this->app['twig']->getExtension(CalendRExtension::class));
     }
 }

--- a/tests/CalendR/Test/Extension/Twig/CalendRExtensionTest.php
+++ b/tests/CalendR/Test/Extension/Twig/CalendRExtensionTest.php
@@ -21,7 +21,7 @@ class CalendRExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->calendar = $this->getMock('CalendR\Calendar');
+        $this->calendar = $this->createMock('CalendR\Calendar');
         $this->object   = new CalendRExtension($this->calendar);
     }
 
@@ -43,7 +43,7 @@ class CalendRExtensionTest extends \PHPUnit_Framework_TestCase
     public function testItCallsCalendarFunctions()
     {
         foreach (array('year', 'month', 'week', 'day') as $periodName) {
-            $period = $this->getMock('CalendR\Perdiod\PeriodInterface');
+            $period = $this->createMock('CalendR\Period\PeriodInterface');
             $this->calendar
                 ->expects($this->once())
                 ->method('get' . ucfirst($periodName))
@@ -53,8 +53,8 @@ class CalendRExtensionTest extends \PHPUnit_Framework_TestCase
             $this->assertSame($period, $this->object->{'get' . ucfirst($periodName)}('foo', 'bar'));
         }
 
-        $events = array($this->getMock('CalendR\Event\EventInterface'));
-        $period = $this->getMock('CalendR\Period\PeriodInterface');
+        $events = array($this->createMock('CalendR\Event\EventInterface'));
+        $period = $this->createMock('CalendR\Period\PeriodInterface');
         $this->calendar
             ->expects($this->once())
             ->method('getEvents')

--- a/tests/CalendR/Test/Period/SecondTest.php
+++ b/tests/CalendR/Test/Period/SecondTest.php
@@ -2,6 +2,7 @@
 
 namespace CalendR\Test\Period;
 
+use CalendR\Period\Exception\NotASecond;
 use CalendR\Period\FactoryInterface;
 use CalendR\Period\Second;
 use CalendR\Period\Minute;
@@ -57,10 +58,14 @@ class SecondTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider providerConstructInvalid
-     * @expectedException \CalendR\Period\Exception\NotASecond
      */
     public function testConstructInvalid($start)
     {
+        // microseconds are valid for PHP 7.1+ due to new DateTime default
+        if (PHP_VERSION_ID < 70100) {
+            $this->expectException(NotASecond::class);
+        }
+
         new Second($start, $this->prophesize(FactoryInterface::class)->reveal());
     }
 


### PR DESCRIPTION
This is the same as @garak's [PR](https://github.com/yohang/CalendR/pull/49), but also fixes tests and allows for PHP 7.1 default `DateTime` constructing with microseconds.  PHPUnit is upgraded, dropping support for PHP < 5.6.