### PR TITLE
Fix comparison for period containing event

### DIFF
--- a/src/CalendR/Period/PeriodAbstract.php
+++ b/src/CalendR/Period/PeriodAbstract.php
@@ -121,7 +121,7 @@ abstract class PeriodAbstract implements PeriodInterface
             $event->containsPeriod($this) ||
             $event->isDuring($this) ||
             $this->contains($event->getBegin()) ||
-            ($event->getEnd() && $this->contains($event->getEnd()))
+            ($event->getEnd() && $this->contains($event->getEnd())  && $event->getEnd()->format('c') !== $this->begin->format('c'))
         ;
     }
 


### PR DESCRIPTION
Do not includes events that ends at the beginning of period